### PR TITLE
Removed setGenerationTimeMs causing error since removed in version 4.0.0

### DIFF
--- a/addon/src/main/java/org/vaadin/matomotracker/tracking/MatomoTracker.java
+++ b/addon/src/main/java/org/vaadin/matomotracker/tracking/MatomoTracker.java
@@ -260,7 +260,6 @@ public class MatomoTracker {
         matomo("setCustomUrl", location);
         if (title != null) matomo("setDocumentTitle", title);
         matomo("deleteCustomVariables","page");
-        matomo("setGenerationTimeMs",0);
         matomo("trackPageView");
     }
 


### PR DESCRIPTION
Causes errors in the browser due to method setGenerationTimeMs removal in version 4.0.0 of Matomo

https://developer.matomo.org/changelog